### PR TITLE
ruby 3.2.0 breaks 'exists?'

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ such as:
 	config[:weather_api_key] = "your-api-key-here"
 
 Install
+
+	gem install ffi
+ 
 [i3status](https://i3wm.org/i3status/)
 and
 [configure it](https://github.com/jcs/dotfiles/blob/master/.i3status.conf).

--- a/sdorfehs-bar.rb
+++ b/sdorfehs-bar.rb
@@ -76,7 +76,7 @@ config = {
 }
 
 # override defaults by eval'ing ~/.config/sdorfehs/bar-config.rb
-if File.exists?(f = "#{ENV["HOME"]}/.config/sdorfehs/bar-config.rb")
+if File.exist?(f = "#{ENV["HOME"]}/.config/sdorfehs/bar-config.rb")
   eval(File.read(f))
 end
 
@@ -186,7 +186,7 @@ class Controller
 
     @mutex = Mutex.new
 
-    if File.exists?(@config[:fifo_path])
+    if File.exist?(@config[:fifo_path])
       File.unlink(@config[:fifo_path])
     end
     File.mkfifo(@config[:fifo_path])
@@ -203,7 +203,7 @@ class Controller
   end
 
   def run!
-    if !File.exists?("/usr/local/bin/i3status")
+    if !File.exist?("/usr/local/bin/i3status")
       STDERR.puts "i3status not found"
       exit 1
     end


### PR DESCRIPTION
Updated 'exists?' with 'exist?' so ruby will run the code. Also ruby was complaing that ffi wasn't installed.
The bar runs on Openbsd 7.5 with ruby 3.3.2.